### PR TITLE
feat: add Swagger universal types and utilities for API documentation

### DIFF
--- a/src/index.node.ts
+++ b/src/index.node.ts
@@ -43,3 +43,9 @@ export {
 export {
     parsePackageJsonEnvironments
 } from "./node/apps/utils.environment.js";
+
+// Swagger universal types and utilities
+export {
+    type AppSchemaTemplate,
+    SwaggerTypes
+} from "./node/api/swagger.universal.js";

--- a/src/node/api/swagger.universal.ts
+++ b/src/node/api/swagger.universal.ts
@@ -1,0 +1,26 @@
+/**
+ * Universal Swagger types and utilities
+ * This interface can be extended for more precise typing if needed.
+ */
+export interface AppSchemaTemplate {
+  body?: Record<string, any>;
+  querystring?: Record<string, any>;
+  params?: Record<string, any>;
+  headers?: Record<string, any>;
+  response?: Record<string, any>;
+  description?: string;
+  tags?: string[];
+  summary?: string;
+  [key: string]: any;
+}
+
+/**
+ * Shared swagger types used in API documentation
+ */
+export enum SwaggerTypes {
+  String = "string",
+  Number = "number",
+  Object = "object",
+  Array = "array",
+  Boolean = "boolean"
+}


### PR DESCRIPTION
This pull request introduces universal Swagger types and utilities to the codebase, improving API documentation support and enabling more consistent typing for API schemas.

API documentation and typing improvements:

* Added a new `AppSchemaTemplate` interface to `src/node/api/swagger.universal.ts` for defining API schema structures, including support for bodies, query strings, parameters, headers, responses, and additional metadata.
* Introduced a `SwaggerTypes` enum in `src/node/api/swagger.universal.ts` to standardize common Swagger data types such as string, number, object, array, and boolean.
* Exported the new `AppSchemaTemplate` type and `SwaggerTypes` enum from `src/index.node.ts` for universal use throughout the project.