### PR TITLE
Refactor: Enhance NodeWithNeighbours interface

### DIFF
--- a/src/globals/panther/models.nodes.structure.ts
+++ b/src/globals/panther/models.nodes.structure.ts
@@ -36,11 +36,13 @@ export interface HasEdges{
 /**
  * Represents a node and its neighbouring nodes.
  *
- * @typeParam T - The type of the node and its neighbours.
+ * @typeParam T - The type of the node.
+ * @typeParam U - The type of the neighbours.
  * @property node - The main node, or `null` if not present.
  * @property neighbours - An array of neighbouring nodes.
- * @property edges - An array of edges connecting the node to its neighbours.
  */
-export interface NodeWithNeighbours<T> extends HasNeighbours<T>, HasEdges {
-    node: T;
+export interface NodeWithNeighbours<T, U>{
+    node: T ;
+    neighbours: U[];
+    edges: GraphEdge[];
 }


### PR DESCRIPTION
This pull request updates the `NodeWithNeighbours` interface in `src/globals/panther/models.nodes.structure.ts` to improve its flexibility and type safety. The interface now allows specifying different types for the node and its neighbours, and explicitly defines the types for `neighbours` and `edges`.

**Type system improvements:**

* Updated the `NodeWithNeighbours` interface to accept two type parameters: `T` for the node and `U` for the neighbours, making it more flexible and type-safe. Also, explicitly defined the types for `neighbours` as `U[]` and `edges` as `GraphEdge[]`.