### PR TITLE
fix: types were gone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ CONTRIBUTING.md
 GEMINI.md
 CLAUDE.md
 AGENTS.md
+.agents/

--- a/tsconfig.prod.browser.json
+++ b/tsconfig.prod.browser.json
@@ -2,9 +2,11 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
+    "rootDir": "src",
     "target": "esnext",
     "module": "esnext",
     "moduleResolution": "bundler"
   },
+  "include": ["src/index.browser.ts"],
   "exclude": ["node_modules", "dist", "tests", "**/*.test.ts", "**/*.spec.ts", "vitest.config.ts"]
 }

--- a/tsconfig.prod.node.json
+++ b/tsconfig.prod.node.json
@@ -2,6 +2,7 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
+    "rootDir": "src",
     "target": "es2024",
     "module": "nodenext",
     "moduleResolution": "nodenext",
@@ -9,5 +10,6 @@
       "node",
     ],
   },
+  "include": ["src/index.node.ts"],
   "exclude": ["node_modules", "dist", "tests", "**/*.test.ts", "**/*.spec.ts", "vitest.config.ts"]
 }


### PR DESCRIPTION
This pull request updates the TypeScript production configuration files for both browser and Node.js builds. The main goal is to clarify the source directory and entry points, which helps ensure the correct files are included during the build process.

Configuration improvements:

* Added `"rootDir": "src"` to both `tsconfig.prod.browser.json` and `tsconfig.prod.node.json` to explicitly set the source directory for the compiler. [[1]](diffhunk://#diff-91a13700aee93a061c8ed1edfa76ea7504fc6afb1e14be2a4040cc300b2a27a9R5-R10) [[2]](diffhunk://#diff-0f0627027e554e4a2d74292a68f522ace97cb67f8c8377768665101b5dee9023R5-R13)
* Specified the entry point for each build by adding the `include` field: `src/index.browser.ts` for the browser config and `src/index.node.ts` for the Node.js config. [[1]](diffhunk://#diff-91a13700aee93a061c8ed1edfa76ea7504fc6afb1e14be2a4040cc300b2a27a9R5-R10) [[2]](diffhunk://#diff-0f0627027e554e4a2d74292a68f522ace97cb67f8c8377768665101b5dee9023R5-R13)… and include paths