### PR TITLE
fix: lazy load sqlite3 native module to prevent GLIBC errors at import time

### DIFF
--- a/src/node/sqlite/sqlite.connection.ts
+++ b/src/node/sqlite/sqlite.connection.ts
@@ -1,4 +1,4 @@
-import sqlite3 from 'sqlite3';
+import type sqlite3 from 'sqlite3';
 import { Database, open } from 'sqlite';
 import { UsedSqlTables } from './enums.sqlite';
 
@@ -25,6 +25,7 @@ export type AppDb = Database<sqlite3.Database, sqlite3.Statement>
  * ```
  */
 export async function openDb(filename: string): Promise<AppDb> {
+	const { default: sqlite3 } = await import('sqlite3');
 	const db = await open({
 		filename, //database file will be created if it does not exist
 		driver: sqlite3.Database,


### PR DESCRIPTION
## Summary
- Convert sqlite3 static import to lazy dynamic import in sqlite.connection.ts

## Problem
- Importing `@gisatcz/ptr-be-core/node` eagerly loads the sqlite3 native addon at module evaluation time
- Applications that never use SQLite still crash with `Error: version GLIBC_2.38 not found` because sqlite3 was compiled against a newer GLIBC

## Solution
- Change `import sqlite3 from 'sqlite3'` to `import type sqlite3 from 'sqlite3'` (erased at compile time)
- Move the runtime import inside `openDb()` via `const { default: sqlite3 } = await import('sqlite3')`
- The sqlite3 native module now loads only when `openDb()` is actually called, never at import time

## Changes
- src/node/sqlite/sqlite.connection.ts — 2 insertions, 1 deletion: type-only import + dynamic import inside openDb()

## Verification
- `npm run build` succeeds
- `npm run lint` passes
- `npm test` — all 32 tests pass
- ESM and CJS bundles both preserve `import('sqlite3')` as a true dynamic import (confirmed by inspecting dist/)