### PR TITLE
chore: align Notion issue sync cron schedule with documentation

### DIFF
--- a/.github/workflows/issues-sync.yml
+++ b/.github/workflows/issues-sync.yml
@@ -2,7 +2,7 @@ name: Sync GitHub Issues to Notion
 
 on:
   schedule:
-    - cron: '14 */6 * * *' # Every 6 hours at minute 14
+    - cron: '27 */4 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Updated the Notion issue sync cron schedule to match the documented standard pattern.

## Problem
- The local `.github/workflows/issues-sync.yml` still used the old `14 */6 * * *` cadence.

## Solution
- Replaced the cron expression with the documented `27 */4 * * *` pattern.

## Changes
- `.github/workflows/issues-sync.yml` — updated `schedule.cron` value