### PR TITLE
refactor: align interval property naming

### DIFF
--- a/src/globals/coding/code.dates.ts
+++ b/src/globals/coding/code.dates.ts
@@ -83,7 +83,7 @@ export const isoIntervalToTimestamps = (interval: string): [number, number] => {
   // valid interval with two parts
   else {
     if (!intervals.every(interval => hasIsoFormat(interval)))
-      throw new InvalidRequestError("Parameter utcIntervalIso is not ISO 8601 time interval (date01/date02) or year");
+      throw new InvalidRequestError("Parameter intervalIso is not ISO 8601 time interval (date01/date02) or year");
 
     const [int1, int2] = intervals.map(intervalIso => {
       const cleared = intervalIso.replace(" ", "")

--- a/src/globals/panther/models.nodes.properties.general.ts
+++ b/src/globals/panther/models.nodes.properties.general.ts
@@ -3,7 +3,7 @@
  * Example: Period is connected to some time range.
  */
 export interface HasInterval {
-    validIntervalIso: string,
+    intervalIso: string,
     validFrom: number,
     validTo: number
 }

--- a/src/node/api/parse.changeNodes.ts
+++ b/src/node/api/parse.changeNodes.ts
@@ -62,15 +62,15 @@ const paseHasLevels = (levelBody: unknown): HasLevels => {
  */
 const parseWithInterval = (bodyRaw: any): HasInterval => {
   const {
-    intervalISO,
+    intervalIso,
   } = bodyRaw
 
-  if (!intervalISO)
+  if (!intervalIso)
     throw new InvalidRequestError("Period must have UTC interval in ISO format")
 
-  const [from, to] = isoIntervalToTimestamps(intervalISO)
+  const [from, to] = isoIntervalToTimestamps(intervalIso)
   const intervalResult: HasInterval = {
-    validIntervalIso: intervalISO,
+    intervalIso,
     validFrom: from,
     validTo: to
   }

--- a/tests/fixtures/arrows.import.allNodes.json
+++ b/tests/fixtures/arrows.import.allNodes.json
@@ -103,7 +103,7 @@
         "nameInternal": "test",
         "nameDisplay": "displayTest",
         "description": "Long Description",
-        "intervalISO": "2020/2025"
+        "intervalIso": "2020/2025"
       },
       "style": {}
     },
@@ -184,7 +184,7 @@
         "description": "Long Description",
         "table": "testTableInPostgis",
         "columns": "test01,test02",
-        "intervalISO": "2020/2025",
+        "intervalIso": "2020/2025",
         "step": "year",
         "documentId": "someVector"
       },

--- a/tests/functional/parsers.graphs.spec.ts
+++ b/tests/functional/parsers.graphs.spec.ts
@@ -59,7 +59,7 @@ describe("Parse graph structures (nodes and edges)", () => {
     expect(datasourceTimeseriesVector?.documentId).toBeDefined()
     expect(datasourceTimeseriesVector?.validFrom).toBeDefined()
     expect(datasourceTimeseriesVector?.validTo).toBeDefined()
-    expect(datasourceTimeseriesVector?.validIntervalIso).toBeDefined()
+    expect(datasourceTimeseriesVector?.intervalIso).toBeDefined()
     expect(datasourceTimeseriesVector?.step).toBeDefined()
 
     const timeseriesEdge = findEdgeByLabel(edges, UsedEdgeLabels.InPostgisLocation)


### PR DESCRIPTION
## Summary
- Align the interval property name to a single canonical name `intervalIso` across interfaces, parsers, error messages, and tests.

## Problem
- The interval property used 3 different names (`validIntervalIso`, `intervalISO`, `utcIntervalIso`) across the codebase, causing confusion for API consumers and downstream services (e.g., `be-metadata` Swagger schema).

## Solution
- Renamed all variants to `intervalIso` to establish a single canonical name.

## Changes
- `src/globals/panther/models.nodes.properties.general.ts` — Rename `validIntervalIso` → `intervalIso` in `HasInterval` interface
- `src/node/api/parse.changeNodes.ts` — Rename input `intervalISO` → `intervalIso` and output `validIntervalIso` → `intervalIso`
- `src/globals/coding/code.dates.ts` — Update error message from `utcIntervalIso` → `intervalIso`
- `tests/fixtures/arrows.import.allNodes.json` — Rename `intervalISO` → `intervalIso`
- `tests/functional/parsers.graphs.spec.ts` — Update assertion from `validIntervalIso` → `intervalIso

Closes #56
