### PR TITLE
fix: rename validFrom/validTo to timestampFrom/timestampTo

### DIFF
--- a/src/globals/panther/models.nodes.properties.general.ts
+++ b/src/globals/panther/models.nodes.properties.general.ts
@@ -4,8 +4,8 @@
  */
 export interface HasInterval {
     intervalIso: string,
-    validFrom: number,
-    validTo: number
+    timestampFrom: number,
+    timestampTo: number
 }
 
 /**

--- a/src/node/api/parse.changeNodes.ts
+++ b/src/node/api/parse.changeNodes.ts
@@ -71,8 +71,8 @@ const parseWithInterval = (bodyRaw: any): HasInterval => {
   const [from, to] = isoIntervalToTimestamps(intervalIso)
   const intervalResult: HasInterval = {
     intervalIso,
-    validFrom: from,
-    validTo: to
+    timestampFrom: from,
+    timestampTo: to
   }
 
   return intervalResult

--- a/tests/functional/parsers.graphs.spec.ts
+++ b/tests/functional/parsers.graphs.spec.ts
@@ -57,8 +57,8 @@ describe("Parse graph structures (nodes and edges)", () => {
     const datasourceTimeseriesVector = findNodeByLabel(nodes, UsedDatasourceLabels.Timeseries)
 
     expect(datasourceTimeseriesVector?.documentId).toBeDefined()
-    expect(datasourceTimeseriesVector?.validFrom).toBeDefined()
-    expect(datasourceTimeseriesVector?.validTo).toBeDefined()
+    expect(datasourceTimeseriesVector?.timestampFrom).toBeDefined()
+    expect(datasourceTimeseriesVector?.timestampTo).toBeDefined()
     expect(datasourceTimeseriesVector?.intervalIso).toBeDefined()
     expect(datasourceTimeseriesVector?.step).toBeDefined()
 


### PR DESCRIPTION
## Summary
- Rename `validFrom`/`validTo` properties to `timestampFrom`/`timestampTo` in the `HasInterval` interface and all related code.

## Problem
The `HasInterval` interface has `intervalIso` (ISO string) alongside `validFrom`/`validTo` (timestamps in ms). The names `validFrom`/`validTo` are not self-explanatory — it's unclear that these are timestamps derived from the ISO interval.

## Solution
Rename to `timestampFrom`/`timestampTo` to clearly indicate these are timestamp values (in ms) parsed from the ISO interval string.

## Changes
- `src/globals/panther/models.nodes.properties.general.ts` — Renamed interface fields
- `src/node/api/parse.changeNodes.ts` — Updated property assignments in `parseWithInterval`
- `tests/functional/parsers.graphs.spec.ts` — Updated test assertions