### PR TITLE
chore(release): pin semantic-release plugins to last known working versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,12 +53,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npx --package semantic-release \
-            --package @semantic-release/commit-analyzer \
-            --package @semantic-release/release-notes-generator \
-            --package @semantic-release/changelog \
-            --package @semantic-release/npm \
-            --package @semantic-release/github \
-            --package @semantic-release/git \
-            --package conventional-changelog-conventionalcommits \
+          npx --package semantic-release@25.0.3 \
+            --package @semantic-release/commit-analyzer@13.0.1 \
+            --package @semantic-release/release-notes-generator@14.1.1 \
+            --package @semantic-release/changelog@6.0.3 \
+            --package @semantic-release/npm@13.1.5 \
+            --package @semantic-release/github@12.0.8 \
+            --package @semantic-release/git@10.0.1 \
+            --package conventional-changelog-conventionalcommits@9.3.1 \
             semantic-release


### PR DESCRIPTION
## Summary

Pin all semantic-release plugin versions in the release workflow to the exact versions used by the last release with correct changelog output (v58.0.0).

## Problem

Releases v58.0.1 and v58.0.2 shipped with empty release notes (no Features, Bug Fixes, or Breaking Changes sections). This was caused by `conventional-changelog-conventionalcommits@10` resolving automatically — its v10 breaking change is incompatible with `@semantic-release/release-notes-generator@14.1.1`, producing only a version header in the release body.

Upstream issue: [semantic-release/release-notes-generator#992](https://github.com/semantic-release/release-notes-generator/issues/992)

## Solution

Pin every plugin in the `npx --package` invocation to the versions from v58.0.0 (the last release with correct changelog output):

| Plugin | Pinned Version |
|--------|---------------|
| `semantic-release` | `25.0.3` |
| `@semantic-release/commit-analyzer` | `13.0.1` |
| `@semantic-release/release-notes-generator` | `14.1.1` |
| `@semantic-release/changelog` | `6.0.3` |
| `@semantic-release/npm` | `13.1.5` |
| `@semantic-release/github` | `12.0.8` |
| `@semantic-release/git` | `10.0.1` |
| `conventional-changelog-conventionalcommits` | `9.3.1` |

## Changes

- `.github/workflows/release.yml` — added explicit version pins to all `npx --package` arguments

## Verification

The next release after merging will use the pinned versions. Verify the GitHub Release body contains the expected changelog sections (Features, Bug Fixes, etc.) instead of just the version header.
