### PR TITLE
65 sql builder inside npm

### DIFF
--- a/docs/npm-refresh-commands.md
+++ b/docs/npm-refresh-commands.md
@@ -1,6 +1,6 @@
 # NPM Refresh Commands
 
-This document contains the commands for a clean reinstall of every declared NPM package. Remove the existing install and lockfile first, then reinstall the latest compatible releases.
+Clean reinstall of every declared NPM package. Remove the existing install and lockfile first, then reinstall the latest major versions of all packages.
 
 ## Clean existing install
 
@@ -15,7 +15,8 @@ There are currently no packages in `peerDependencies`, so no peer-dependency ins
 ## Install development dependencies
 
 ```sh
-npm install @types/node@latest vitest@latest @stylistic/eslint-plugin@latest eslint@latest typescript-eslint@latest @rollup/plugin-node-resolve@latest @rollup/plugin-typescript@latest rollup@latest tslib@latest typescript@6.0.3 vite@latest --save-dev
+npm install @types/node@latest vitest@latest @stylistic/eslint-plugin@latest eslint@latest typescript-eslint@latest @rollup/plugin-node-resolve@latest @rollup/plugin-typescript@latest rollup@latest tslib@latest vite@latest --save-dev
+npm install typescript@6.0.3 --save-dev
 ```
 
-TypeScript is pinned to the newest compatible 6.x release because `typescript-eslint@8.67.0` requires TypeScript `<6.1.0`.
+TypeScript is pinned to the newest 6.x release because `typescript-eslint@8.67.0` requires TypeScript `<6.1.0` and the latest release is 7.x.

--- a/package-lock.json
+++ b/package-lock.json
@@ -210,9 +210,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -325,9 +322,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -345,9 +339,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -365,9 +356,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -385,9 +373,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -405,9 +390,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -425,9 +407,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -662,9 +641,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -679,9 +655,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -696,9 +669,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -713,9 +683,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -730,9 +697,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -747,9 +711,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -764,9 +725,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -781,9 +739,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -798,9 +753,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -815,9 +767,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -832,9 +781,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -849,9 +795,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -866,9 +809,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1570,9 +1510,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
-      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
       "dev": true,
       "license": "MIT"
     },
@@ -2194,9 +2134,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2218,9 +2155,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2242,9 +2176,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2266,9 +2197,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -32,19 +32,18 @@
     "before:push": "npm run format && npm run lint && npm run build && npm run test",
     "pack:check": "npm pack --dry-run"
   },
-  "peerDependencies": {},
   "devDependencies": {
     "@types/node": "^26.2.0",
     "vitest": "^4.1.10",
-    "@stylistic/eslint-plugin": "^5.10.0",
     "eslint": "^10.8.1",
+    "@stylistic/eslint-plugin": "^5.10.0",
     "typescript-eslint": "^8.67.0",
+    "rollup": "^4.62.4",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-typescript": "^12.3.0",
-    "rollup": "^4.62.4",
-    "tslib": "^2.8.1",
+    "vite": "^8.2.1",
     "typescript": "^6.0.3",
-    "vite": "^8.2.1"
+    "tslib": "^2.8.1"
   },
   "repository": {
     "type": "git",

--- a/src/globals/filtering/convertor.sql.csv.ts
+++ b/src/globals/filtering/convertor.sql.csv.ts
@@ -9,20 +9,28 @@
 
 /** Describes a filter query for Panther attribute-based filtering. */
 export interface PantherAttributeQuery {
+
     /** Chaining info: empty for first filter, "and" or "or" for subsequent ones. */
     chainingInfo?: "and" | "or"
+
     /** Attribute name to filter on. */
     attributeName: string
+
     /** Lower bound for range filtering. */
     fromValue?: number
+
     /** Upper bound for range filtering. */
     toValue?: number
+
     /** Exact match value (string, number, or boolean). */
     equal?: string | number | boolean
+
     /** Column to order results by. */
     orderBy?: string
+
     /** Sort direction. */
     ascending: "ascend" | "descend"
+
     /** Column to group results by. */
     groupBy?: string
 }
@@ -36,27 +44,58 @@ export interface PantherAttributeQuery {
 export const PantherFilter = () => {
     // Accumulate committed filters; current is the one being edited
     const filters: PantherAttributeQuery[] = []
+
     let current: PantherAttributeQuery = {} as any
 
     // Expose chainable setters and terminal methods
     const build = {
+
+        /** Set the attribute name to filter on. */
         attribute: (name: string) => (current.attributeName = name, build),
+
+        /** Set the lower bound for range filtering. */
         from: (value: number) => (current.fromValue = value, build),
+
+        /** Set the upper bound for range filtering. */
         to: (value: number) => (current.toValue = value, build),
+
+        /** Set an exact match value (string, number, or boolean). */
         equal: (value: string | number | boolean) => (current.equal = value, build),
+
+        /** Set the column to order results by. */
         orderBy: (column: string) => (current.orderBy = column, build),
+
+        /** Set sort direction to ascending. */
         ascend: () => (current.ascending = "ascend", build),
+
+        /** Set sort direction to descending. */
         descend: () => (current.ascending = "descend", build),
+
+        /** Set the column to group results by. */
         groupBy: (column: string) => (current.groupBy = column, build),
-        /** Commit current filter and start a new one with the given chaining operator. */
+
+        /**
+         * Commit current filter and start a new one with the given chaining operator.
+         *
+         * @param name - Attribute name for the next filter.
+         * @param chaining - Logical connector: "and" or "or".
+         * @returns The builder instance for further chaining.
+         */
         nextAttribute: (name: string, chaining: "and" | "or") => {
             filters.push({ ...current })
             current = { attributeName: name, chainingInfo: chaining } as any
+
             return build
         },
+
         /** Return all filters assembled so far. */
         result: () => [...filters, { ...current }],
-        /** Serialise all filters into multi-line CSV, preserving empty slots for unset fields. */
+
+        /**
+         * Serialise all filters into multi-line CSV, preserving empty slots for unset fields.
+         *
+         * @returns Multi-line CSV string with one filter per row.
+         */
         returnCSV: () => [...filters, current].map((f) => [
             f.chainingInfo ?? "",
             f.attributeName,
@@ -81,11 +120,19 @@ export const PantherFilter = () => {
  */
 export const parsePantherFilterCSV = (lines: string): PantherAttributeQuery[] => {
 
-    /** Converts a raw CSV field back into a boolean, number, or string value. */
+    /**
+     * Converts a raw CSV field back into a boolean, number, or string value.
+     *
+     * @param value - Raw string from the CSV field.
+     * @returns The value as boolean, number, or original string.
+     */
     const parseCSVValue = (value: string): string | number | boolean => {
         if (value === "true") return true
+
         if (value === "false") return false
+
         if (value !== "" && !isNaN(Number(value))) return Number(value)
+
         return value
     }
 

--- a/src/globals/filtering/convertor.sql.csv.ts
+++ b/src/globals/filtering/convertor.sql.csv.ts
@@ -1,5 +1,5 @@
 /**
- * CSV Tansport format
+ * INFO: CSV Tansport format
  * We encode the filter into CSV format
  * The singe filter is a single CSL line
  * Format : chainingInfo,  attibute , fromValue , toValue , equal , orderBy , ascending , groupBy
@@ -57,7 +57,7 @@ export const PantherFilter = () => {
         /** Return all filters assembled so far. */
         result: () => [...filters, { ...current }],
         /** Serialise all filters into multi-line CSV, preserving empty slots for unset fields. */
-        returnLineCSV: () => [...filters, current].map((f) => [
+        returnCSV: () => [...filters, current].map((f) => [
             f.chainingInfo ?? "",
             f.attributeName,
             f.fromValue,
@@ -72,14 +72,6 @@ export const PantherFilter = () => {
     return build
 }
 
-/** Converts a raw CSV field back into a boolean, number, or string value. */
-const parseCSVValue = (value: string): string | number | boolean => {
-    if (value === "true") return true
-    if (value === "false") return false
-    if (value !== "" && !isNaN(Number(value))) return Number(value)
-    return value
-}
-
 /**
  * Parses multi-line CSV (one filter per row) back into an array of {@link PantherAttributeQuery}.
  * Empty slots become undefined; numeric and boolean values are converted back to native types.
@@ -87,7 +79,16 @@ const parseCSVValue = (value: string): string | number | boolean => {
  * @param lines - Multi-line CSV produced by `returnLineCSV`.
  * @returns The reconstructed list of filter queries.
  */
-export const parseFilterCSV = (lines: string): PantherAttributeQuery[] => {
+export const parsePantherFilterCSV = (lines: string): PantherAttributeQuery[] => {
+
+    /** Converts a raw CSV field back into a boolean, number, or string value. */
+    const parseCSVValue = (value: string): string | number | boolean => {
+        if (value === "true") return true
+        if (value === "false") return false
+        if (value !== "" && !isNaN(Number(value))) return Number(value)
+        return value
+    }
+
     return lines.split("\n")
         .filter((line) => line.trim() !== "")
         .map((line) => {

--- a/src/globals/filtering/convertor.sql.csv.ts
+++ b/src/globals/filtering/convertor.sql.csv.ts
@@ -1,17 +1,31 @@
+/** Describes a filter query for Panther attribute-based filtering. */
 export interface PantherAttributeQuery {
+    /** Attribute name to filter on. */
     attributeName: string
+    /** Lower bound for range filtering. */
     fromValue?: number
+    /** Upper bound for range filtering. */
     toValue?: number
+    /** Exact match value (string, number, or boolean). */
     equal?: string | number | boolean
+    /** Column to order results by. */
     orderBy?: string
+    /** Sort direction. */
     ascending: "ascend" | "descend"
+    /** Column to group results by. */
     groupBy?: string
 }
 
-
+/**
+ * Creates a fluent builder for constructing a {@link PantherAttributeQuery}.
+ *
+ * @returns An object with chained setter methods and a final `result()` accessor.
+ */
 export const PantherFilter = () => {
+    // Initialise empty filter object
     let filter: PantherAttributeQuery = {} as any
 
+    // Expose chainable setters and a terminal result method
     const build = {
         attribute: (name: string) => (filter.attributeName = name, build),
         from: (value: number) => (filter.fromValue = value, build),
@@ -21,6 +35,7 @@ export const PantherFilter = () => {
         ascend: () => (filter.ascending = "ascend", build),
         descend: () => (filter.ascending = "descend", build),
         groupBy: (column: string) => (filter.groupBy = column, build),
+        /** Return a shallow copy of the assembled filter object. */
         result: () => ({ ...filter })
     }
 

--- a/src/globals/filtering/convertor.sql.csv.ts
+++ b/src/globals/filtering/convertor.sql.csv.ts
@@ -1,0 +1,28 @@
+export interface PantherAttributeQuery {
+    attributeName: string
+    fromValue?: number
+    toValue?: number
+    equal?: string | number | boolean
+    orderBy?: string
+    ascending: "ascend" | "descend"
+    groupBy?: string
+}
+
+
+export const PantherFilter = () => {
+    let filter: PantherAttributeQuery = {} as any
+
+    const build = {
+        attribute: (name: string) => (filter.attributeName = name, build),
+        from: (value: number) => (filter.fromValue = value, build),
+        to: (value: number) => (filter.toValue = value, build),
+        equal: (value: string | number | boolean) => (filter.equal = value, build),
+        orderBy: (column: string) => (filter.orderBy = column, build),
+        ascend: () => (filter.ascending = "ascend", build),
+        descend: () => (filter.ascending = "descend", build),
+        groupBy: (column: string) => (filter.groupBy = column, build),
+        result: () => ({ ...filter })
+    }
+
+    return build
+}

--- a/src/globals/filtering/convertor.sql.csv.ts
+++ b/src/globals/filtering/convertor.sql.csv.ts
@@ -4,6 +4,11 @@
  * The singe filter is a single CSL line
  * Format : chainingInfo,  attibute , fromValue , toValue , equal , orderBy , ascending , groupBy
  * ChainingInfo: empty for first row, then "and" or "or"
+ *
+ * Transport: `webEncodeFilterCSV` wraps this CSV in a single-line
+ * RFC 4648 §5 Base64url string (URL-safe, unpadded) for opacity and safe
+ * use in URLs/query params. A consuming backend must decode with the same
+ * scheme. This is encoding for compactness, not encryption.
  */
 
 
@@ -105,7 +110,15 @@ export const PantherFilter = () => {
             f.orderBy,
             f.ascending,
             f.groupBy
-        ].map((v) => v ?? "").join(", ")).join("\n")
+        ].map((v) => v ?? "").join(", ")).join("\n"),
+
+        /**
+         * Serialize all filters into the single-line RFC 4648 §5 Base64url
+         * transport string (opaque, URL-safe). Decode with `webDecodeFilterCSV`.
+         *
+         * @returns The Base64url-encoded transport string.
+         */
+        returnEncodedCSV: () => webEncodeFilterCSV([...filters, current])
     }
 
     return build
@@ -155,4 +168,96 @@ export const parsePantherFilterCSV = (lines: string): PantherAttributeQuery[] =>
                 groupBy: groupBy !== "" ? groupBy : undefined
             }
         })
+}
+
+/**
+ * Encodes a string into RFC 4648 §5 Base64url (URL-safe, no padding).
+ * Works in both browsers (`btoa`) and Node (`Buffer`).
+ *
+ * @param value - Raw string to encode.
+ * @returns The Base64url-encoded string.
+ */
+const webToBase64url = (value: string): string => {
+    const base64 = typeof Buffer !== "undefined"
+        ? Buffer.from(value, "utf8").toString("base64")
+        : btoa(value)
+
+    return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+}
+
+/**
+ * Decodes a RFC 4648 §5 Base64url string back to its original form.
+ * Throws if the input is not valid Base64url.
+ *
+ * @param value - Base64url-encoded string.
+ * @returns The decoded string.
+ */
+const webFromBase64url = (value: string): string => {
+    const normalized = value.replace(/-/g, "+").replace(/_/g, "/")
+
+    const padded = normalized + "=".repeat((4 - (normalized.length % 4)) % 4)
+
+    if (typeof Buffer !== "undefined") {
+        return Buffer.from(padded, "base64").toString("utf8")
+    }
+
+    return atob(padded)
+}
+
+/**
+ * Builds the same multi-line CSV serialization used by `PantherFilter.returnCSV`
+ * from a list of filter queries.
+ *
+ * @param filters - The filter queries to serialize.
+ * @returns The multi-line CSV string.
+ */
+const toCSV = (filters: PantherAttributeQuery[]): string => filters.map((f) => [
+    f.chainingInfo ?? "",
+    f.attributeName,
+    f.fromValue,
+    f.toValue,
+    f.equal,
+    f.orderBy,
+    f.ascending,
+    f.groupBy
+].map((v) => v ?? "").join(", ")).join("\n")
+
+/**
+ * Serializes filter queries into a single opaque, URL-safe transport string
+ * (RFC 4648 §5 Base64url encoding of the CSV format documented above).
+ *
+ * This does not encrypt the payload; it only makes it compact and hard to
+ * guess. A separate backend must decode it with the same scheme.
+ *
+ * @param filters - The filter queries to encode.
+ * @returns A single-line Base64url string.
+ */
+export const webEncodeFilterCSV = (filters: PantherAttributeQuery[]): string =>
+    webToBase64url(toCSV(filters))
+
+/**
+ * Deserializes a Base64url transport string back into filter queries.
+ *
+ * Validates that the input is a non-empty Base64url string before decoding.
+ *
+ * @param encoded - The single-line Base64url string produced by `webEncodeFilterCSV`.
+ * @returns The reconstructed list of filter queries.
+ * @throws If the input is empty or not valid Base64url encoding.
+ */
+export const webDecodeFilterCSV = (encoded: string): PantherAttributeQuery[] => {
+    if (typeof encoded !== "string" || encoded.trim() === "") {
+        throw new Error("webDecodeFilterCSV: input must be a non-empty Base64url string, got empty value")
+    }
+
+    if (!/^[A-Za-z0-9_-]+$/.test(encoded)) {
+        throw new Error("webDecodeFilterCSV: input contains invalid Base64url characters (expected A-Za-z0-9, '_' or '-')")
+    }
+
+    const csv = webFromBase64url(encoded)
+
+    if (csv.trim() === "") {
+        throw new Error("webDecodeFilterCSV: decoded payload is empty")
+    }
+
+    return parsePantherFilterCSV(csv)
 }

--- a/src/globals/filtering/convertor.sql.csv.ts
+++ b/src/globals/filtering/convertor.sql.csv.ts
@@ -1,3 +1,11 @@
+/**
+ * CSV Tansport format
+ * We encode the filter into CSV format
+ * The singe filter is a single CSL line
+ * Format : attibute , fromValue , toValue , equal , orderBy , ascending , groupBy
+ */
+
+
 /** Describes a filter query for Panther attribute-based filtering. */
 export interface PantherAttributeQuery {
     /** Attribute name to filter on. */
@@ -36,8 +44,50 @@ export const PantherFilter = () => {
         descend: () => (filter.ascending = "descend", build),
         groupBy: (column: string) => (filter.groupBy = column, build),
         /** Return a shallow copy of the assembled filter object. */
-        result: () => ({ ...filter })
+        result: () => ({ ...filter }),
+        /** Serialize the assembled filter into a CSV line, keeping empty slots for unset fields. */
+        returnLineCSV: () => [
+            filter.attributeName,
+            filter.fromValue,
+            filter.toValue,
+            filter.equal,
+            filter.orderBy,
+            filter.ascending,
+            filter.groupBy
+        ].map((v) => v ?? "").join(", ")
     }
 
     return build
+}
+
+/** Converts a raw CSV field back into a boolean, number, or string value. */
+const parseCSVValue = (value: string): string | number | boolean => {
+    if (value === "true") return true
+    if (value === "false") return false
+    if (value !== "" && !isNaN(Number(value))) return Number(value)
+    return value
+}
+
+/**
+ * Parses a CSV line in the declared transport format back into a {@link PantherAttributeQuery}.
+ * Empty slots become undefined; numeric and boolean values are converted back to native types.
+ *
+ * @param line - CSV line produced by `returnLineCSV`.
+ * @returns The reconstructed filter query.
+ */
+export const parseFilterCSV = (line: string): PantherAttributeQuery => {
+    // Split into fields and strip surrounding whitespace
+    const [attributeName, fromValue, toValue, equal, orderBy, ascending, groupBy] =
+        line.split(", ").map((field) => field.trim())
+
+    // Rebuild the filter, leaving empty slots undefined and defaulting sort direction
+    return {
+        attributeName,
+        fromValue: fromValue !== "" ? Number(fromValue) : undefined,
+        toValue: toValue !== "" ? Number(toValue) : undefined,
+        equal: equal !== "" ? parseCSVValue(equal) : undefined,
+        orderBy: orderBy !== "" ? orderBy : undefined,
+        ascending: (ascending === "ascend" || ascending === "descend" ? ascending : "ascend"),
+        groupBy: groupBy !== "" ? groupBy : undefined
+    }
 }

--- a/src/globals/filtering/convertor.sql.csv.ts
+++ b/src/globals/filtering/convertor.sql.csv.ts
@@ -2,12 +2,15 @@
  * CSV Tansport format
  * We encode the filter into CSV format
  * The singe filter is a single CSL line
- * Format : attibute , fromValue , toValue , equal , orderBy , ascending , groupBy
+ * Format : chainingInfo,  attibute , fromValue , toValue , equal , orderBy , ascending , groupBy
+ * ChainingInfo: empty for first row, then "and" or "or"
  */
 
 
 /** Describes a filter query for Panther attribute-based filtering. */
 export interface PantherAttributeQuery {
+    /** Chaining info: empty for first filter, "and" or "or" for subsequent ones. */
+    chainingInfo?: "and" | "or"
     /** Attribute name to filter on. */
     attributeName: string
     /** Lower bound for range filtering. */
@@ -25,36 +28,45 @@ export interface PantherAttributeQuery {
 }
 
 /**
- * Creates a fluent builder for constructing a {@link PantherAttributeQuery}.
+ * Creates a fluent builder for constructing a chain of {@link PantherAttributeQuery} filters.
  *
- * @returns An object with chained setter methods and a final `result()` accessor.
+ * @returns An object with chained setter methods, `nextAttribute` to start the next filter,
+ *          `result()` to get all filters, and `returnLineCSV()` to serialise as multi-line CSV.
  */
 export const PantherFilter = () => {
-    // Initialise empty filter object
-    let filter: PantherAttributeQuery = {} as any
+    // Accumulate committed filters; current is the one being edited
+    const filters: PantherAttributeQuery[] = []
+    let current: PantherAttributeQuery = {} as any
 
-    // Expose chainable setters and a terminal result method
+    // Expose chainable setters and terminal methods
     const build = {
-        attribute: (name: string) => (filter.attributeName = name, build),
-        from: (value: number) => (filter.fromValue = value, build),
-        to: (value: number) => (filter.toValue = value, build),
-        equal: (value: string | number | boolean) => (filter.equal = value, build),
-        orderBy: (column: string) => (filter.orderBy = column, build),
-        ascend: () => (filter.ascending = "ascend", build),
-        descend: () => (filter.ascending = "descend", build),
-        groupBy: (column: string) => (filter.groupBy = column, build),
-        /** Return a shallow copy of the assembled filter object. */
-        result: () => ({ ...filter }),
-        /** Serialize the assembled filter into a CSV line, keeping empty slots for unset fields. */
-        returnLineCSV: () => [
-            filter.attributeName,
-            filter.fromValue,
-            filter.toValue,
-            filter.equal,
-            filter.orderBy,
-            filter.ascending,
-            filter.groupBy
-        ].map((v) => v ?? "").join(", ")
+        attribute: (name: string) => (current.attributeName = name, build),
+        from: (value: number) => (current.fromValue = value, build),
+        to: (value: number) => (current.toValue = value, build),
+        equal: (value: string | number | boolean) => (current.equal = value, build),
+        orderBy: (column: string) => (current.orderBy = column, build),
+        ascend: () => (current.ascending = "ascend", build),
+        descend: () => (current.ascending = "descend", build),
+        groupBy: (column: string) => (current.groupBy = column, build),
+        /** Commit current filter and start a new one with the given chaining operator. */
+        nextAttribute: (name: string, chaining: "and" | "or") => {
+            filters.push({ ...current })
+            current = { attributeName: name, chainingInfo: chaining } as any
+            return build
+        },
+        /** Return all filters assembled so far. */
+        result: () => [...filters, { ...current }],
+        /** Serialise all filters into multi-line CSV, preserving empty slots for unset fields. */
+        returnLineCSV: () => [...filters, current].map((f) => [
+            f.chainingInfo ?? "",
+            f.attributeName,
+            f.fromValue,
+            f.toValue,
+            f.equal,
+            f.orderBy,
+            f.ascending,
+            f.groupBy
+        ].map((v) => v ?? "").join(", ")).join("\n")
     }
 
     return build
@@ -69,25 +81,30 @@ const parseCSVValue = (value: string): string | number | boolean => {
 }
 
 /**
- * Parses a CSV line in the declared transport format back into a {@link PantherAttributeQuery}.
+ * Parses multi-line CSV (one filter per row) back into an array of {@link PantherAttributeQuery}.
  * Empty slots become undefined; numeric and boolean values are converted back to native types.
  *
- * @param line - CSV line produced by `returnLineCSV`.
- * @returns The reconstructed filter query.
+ * @param lines - Multi-line CSV produced by `returnLineCSV`.
+ * @returns The reconstructed list of filter queries.
  */
-export const parseFilterCSV = (line: string): PantherAttributeQuery => {
-    // Split into fields and strip surrounding whitespace
-    const [attributeName, fromValue, toValue, equal, orderBy, ascending, groupBy] =
-        line.split(", ").map((field) => field.trim())
+export const parseFilterCSV = (lines: string): PantherAttributeQuery[] => {
+    return lines.split("\n")
+        .filter((line) => line.trim() !== "")
+        .map((line) => {
+            // Split into 8 columns: chainingInfo, attributeName, fromValue, toValue, equal, orderBy, ascending, groupBy
+            const [chainingInfo, attributeName, fromValue, toValue, equal, orderBy, ascending, groupBy] =
+                line.split(", ").map((field) => field.trim())
 
-    // Rebuild the filter, leaving empty slots undefined and defaulting sort direction
-    return {
-        attributeName,
-        fromValue: fromValue !== "" ? Number(fromValue) : undefined,
-        toValue: toValue !== "" ? Number(toValue) : undefined,
-        equal: equal !== "" ? parseCSVValue(equal) : undefined,
-        orderBy: orderBy !== "" ? orderBy : undefined,
-        ascending: (ascending === "ascend" || ascending === "descend" ? ascending : "ascend"),
-        groupBy: groupBy !== "" ? groupBy : undefined
-    }
+            // Rebuild the filter, leaving empty slots undefined and defaulting sort direction
+            return {
+                chainingInfo: (chainingInfo === "and" || chainingInfo === "or" ? chainingInfo : undefined),
+                attributeName,
+                fromValue: fromValue !== "" ? Number(fromValue) : undefined,
+                toValue: toValue !== "" ? Number(toValue) : undefined,
+                equal: equal !== "" ? parseCSVValue(equal) : undefined,
+                orderBy: orderBy !== "" ? orderBy : undefined,
+                ascending: (ascending === "ascend" || ascending === "descend" ? ascending : "ascend"),
+                groupBy: groupBy !== "" ? groupBy : undefined
+            }
+        })
 }

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -97,5 +97,7 @@ export {
 export {
     PantherFilter,
     parsePantherFilterCSV,
+    webEncodeFilterCSV,
+    webDecodeFilterCSV,
     type PantherAttributeQuery
 } from "./globals/filtering/convertor.sql.csv.js"

--- a/src/index.browser.ts
+++ b/src/index.browser.ts
@@ -93,3 +93,9 @@ export {
     type PantherEntity,
     type FullPantherEntity
 } from "./globals/panther/models.nodes.js";
+
+export {
+    PantherFilter,
+    parsePantherFilterCSV,
+    type PantherAttributeQuery
+} from "./globals/filtering/convertor.sql.csv.js"

--- a/src/node/crypto/crypto.ts
+++ b/src/node/crypto/crypto.ts
@@ -3,5 +3,8 @@ import { createHash } from 'crypto';
 /**
  * Non-cryptographic-safe hash (sha256) used for cache keys
  * Not suitable for security/cryptography purposes
+ *
+ * @param value - Any JSON-serializable value to hash.
+ * @returns Hexadecimal SHA-256 digest as a string.
  */
 export const cryptoNoCrypticHash = (value: unknown) => createHash('sha256').update(JSON.stringify(value)).digest('hex')

--- a/src/node/logging/logger.ts
+++ b/src/node/logging/logger.ts
@@ -5,6 +5,7 @@ import { hostname } from 'node:os'
  */
 const logLevels = ['trace', 'debug', 'info', 'warn', 'error', 'fatal', 'silent'] as const
 
+/** Union of supported log level names derived from the `logLevels` array. */
 type LogLevel = typeof logLevels[number]
 
 // Read log level from environment, default to 'info'
@@ -29,6 +30,9 @@ const consoleMethods: Record<Exclude<LogLevel, 'silent'>, (...data: any[]) => vo
 
 /**
  * Serialize a log entry object to JSON, handling bigints and circular references.
+ *
+ * @param entry - Log entry fields to serialize.
+ * @returns The entry serialized as a JSON string.
  */
 const serialize = (entry: Record<string, any>): string => {
   const ancestors: object[] = []
@@ -52,6 +56,11 @@ const serialize = (entry: Record<string, any>): string => {
 /**
  * Emit a single newline-delimited JSON record through the native console.
  * Skips emission if the entry's level is below the configured threshold.
+ *
+ * @param level - The severity level for this log entry.
+ * @param label - Short classification label.
+ * @param message - Human-readable message body.
+ * @param options - Extra metadata key-value pairs.
  */
 const log = (
   level: Exclude<LogLevel, 'silent'>,

--- a/src/node/panther/parse.changeNodes.ts
+++ b/src/node/panther/parse.changeNodes.ts
@@ -125,10 +125,13 @@ const parseHasGeometry = (bodyRaw: any) => {
     geometry,
   } = bodyRaw
 
-  /**
+/**
    * Convert bbox from CSV string to array of 4 coordinate numbers.
+   *
+   * @returns An array of 4 numbers: [xmin, ymin, xmax, ymax].
+   * @throws {InvalidRequestError} If the parsed bbox does not have exactly 4 values.
    */
-  const bboxFromCSV = () => {
+  const bboxFromCSV = (): number[] => {
     const bboxFromCSV = csvParseNumbers(bbox as string)
 
     // Validate bbox has exactly 4 values (xmin, ymin, xmax, ymax)

--- a/src/node/panther/parse.changesEdges.ts
+++ b/src/node/panther/parse.changesEdges.ts
@@ -15,6 +15,10 @@ export const parseRichEdges = (body: unknown): GraphEdge[] => {
 
     /**
      * Parse a single edge object, validating its label, fromKey, and toKey.
+     *
+     * @param edge - Raw edge object from the request body.
+     * @returns Parsed GraphEdge with validated label, keys, and properties.
+     * @throws {InvalidRequestError} If label, fromKey, or toKey are missing or invalid.
      */
     const parseSingleEdge = (edge: unknown): GraphEdge => {
 
@@ -79,6 +83,10 @@ export const parseEqualEdges = (body: unknown): GraphRelation[] => {
     /**
      * Validate a single edge relation tuple.
      * Must be a two-element array of strings with different values.
+     *
+     * @param edgeRelation - Raw relation tuple from the request body.
+     * @returns Validated GraphRelation tuple.
+     * @throws {InvalidRequestError} If the relation is not a valid two-element tuple.
      */
     const parseSingleEdgeRelation = (edgeRelation: unknown): GraphRelation => {
 

--- a/tests/functional/convertor.sql.csv.spec.ts
+++ b/tests/functional/convertor.sql.csv.spec.ts
@@ -1,0 +1,191 @@
+import { PantherFilter, parsePantherFilterCSV } from "../../src/globals/filtering/convertor.sql.csv"
+
+describe("PantherFilter builder - single filter", () => {
+    test("attribute and range setters build the expected filter", () => {
+        const filter = PantherFilter()
+            .attribute("price")
+            .from(10)
+            .to(100)
+            .orderBy("name")
+            .descend()
+            .groupBy("type")
+            .result()
+
+        expect(filter).toEqual([
+            {
+                attributeName: "price",
+                fromValue: 10,
+                toValue: 100,
+                orderBy: "name",
+                ascending: "descend",
+                groupBy: "type",
+            },
+        ])
+    })
+
+    test("equal accepts string, number, and boolean values", () => {
+        const asString = PantherFilter().attribute("name").equal("foo").result()
+        const asNumber = PantherFilter().attribute("qty").equal(5).result()
+        const asBooleanTrue = PantherFilter().attribute("active").equal(true).result()
+        const asBooleanFalse = PantherFilter().attribute("active").equal(false).result()
+
+        expect(asString[0].equal).toBe("foo")
+        expect(asNumber[0].equal).toBe(5)
+        expect(asBooleanTrue[0].equal).toBe(true)
+        expect(asBooleanFalse[0].equal).toBe(false)
+    })
+
+    test("result returns copies that do not mutate on later setter calls", () => {
+        const builder = PantherFilter().attribute("price").from(1)
+        const first = builder.result()
+        builder.to(99)
+
+        expect(first[0].toValue).toBeUndefined()
+        expect(builder.result()[0].toValue).toBe(99)
+    })
+
+    test("ascend sets the sort direction to ascend", () => {
+        expect(PantherFilter().attribute("a").ascend().result()[0].ascending).toBe("ascend")
+    })
+})
+
+describe("PantherFilter builder - chaining", () => {
+    test("nextAttribute builds multiple chained filters", () => {
+        const filter = PantherFilter()
+            .attribute("a")
+            .nextAttribute("b", "and")
+            .nextAttribute("c", "or")
+            .result()
+
+        expect(filter.length).toBe(3)
+        expect(filter[0].attributeName).toBe("a")
+        expect(filter[0].chainingInfo).toBeUndefined()
+        expect(filter[1].attributeName).toBe("b")
+        expect(filter[1].chainingInfo).toBe("and")
+        expect(filter[2].attributeName).toBe("c")
+        expect(filter[2].chainingInfo).toBe("or")
+    })
+
+    test("setters after nextAttribute apply only to the new filter", () => {
+        const filter = PantherFilter()
+            .attribute("a")
+            .from(1)
+            .nextAttribute("b", "and")
+            .from(99)
+            .result()
+
+        expect(filter[0].fromValue).toBe(1)
+        expect(filter[1].fromValue).toBe(99)
+    })
+})
+
+describe("PantherFilter returnCSV - serialization", () => {
+    test("single filter serializes with empty slots preserved", () => {
+        const line = PantherFilter().attribute("price").from(10).to(100).descend().returnCSV()
+
+        expect(line).toBe(", price, 10, 100, , , descend, ")
+    })
+
+    test("multi-filter chain serializes to newline-joined rows", () => {
+        const csv = PantherFilter()
+            .attribute("price")
+            .descend()
+            .nextAttribute("qty", "and")
+            .equal(5)
+            .ascend()
+            .returnCSV()
+
+        expect(csv).toBe(", price, , , , , descend, \nand, qty, , , 5, , ascend, ")
+    })
+
+    test("or chaining uses or in the chaining column", () => {
+        const csv = PantherFilter()
+            .attribute("a")
+            .nextAttribute("b", "or")
+            .returnCSV()
+
+        expect(csv.split("\n")).toHaveLength(2)
+        expect(csv.split("\n")[1].startsWith("or, ")).toBe(true)
+    })
+})
+
+describe("parsePantherFilterCSV - parsing", () => {
+    test("parses a single line into one filter with native types", () => {
+        const parsed = parsePantherFilterCSV(", price, 10, 100, , name, descend, type")
+
+        expect(parsed).toHaveLength(1)
+        expect(parsed[0]).toEqual({
+            attributeName: "price",
+            fromValue: 10,
+            toValue: 100,
+            orderBy: "name",
+            ascending: "descend",
+            groupBy: "type",
+        })
+    })
+
+    test("converts boolean and number equal values back to native types", () => {
+        const parsed = parsePantherFilterCSV(
+            ", active, , , true, , ascend, \n, qty, , , 5, , ascend, "
+        )
+
+        expect(parsed[0].equal).toBe(true)
+        expect(parsed[1].equal).toBe(5)
+    })
+
+    test("parses multi-line input and sets chainingInfo on subsequent rows", () => {
+        const parsed = parsePantherFilterCSV(
+            ", a, , , , , ascend, \nand, b, , , , , ascend, \nor, c, , , , , ascend, "
+        )
+
+        expect(parsed).toHaveLength(3)
+        expect(parsed[0].chainingInfo).toBeUndefined()
+        expect(parsed[1].chainingInfo).toBe("and")
+        expect(parsed[2].chainingInfo).toBe("or")
+    })
+
+    test("empty slots become undefined instead of empty strings", () => {
+        const parsed = parsePantherFilterCSV(", name, , , , , , ")
+
+        expect(parsed[0].fromValue).toBeUndefined()
+        expect(parsed[0].toValue).toBeUndefined()
+        expect(parsed[0].equal).toBeUndefined()
+        expect(parsed[0].orderBy).toBeUndefined()
+        expect(parsed[0].groupBy).toBeUndefined()
+    })
+
+    test("missing or invalid ascending defaults to ascend", () => {
+        const missing = parsePantherFilterCSV(", a, , , , , , ")
+        const invalid = parsePantherFilterCSV(", a, , , , , sideways, ")
+
+        expect(missing[0].ascending).toBe("ascend")
+        expect(invalid[0].ascending).toBe("ascend")
+    })
+
+    test("skips empty lines and trailing newlines", () => {
+        const parsed = parsePantherFilterCSV("\n  \n, a, , , , , ascend, \n\n, b, , , , , ascend, \n")
+
+        expect(parsed).toHaveLength(2)
+        expect(parsed[0].attributeName).toBe("a")
+        expect(parsed[1].attributeName).toBe("b")
+    })
+})
+
+describe("PantherFilter CSV round-trip", () => {
+    test("returnCSV followed by parsePantherFilterCSV reproduces the filters", () => {
+        const builder = PantherFilter()
+            .attribute("price")
+            .from(10)
+            .to(100)
+            .descend()
+            .nextAttribute("qty", "and")
+            .ascend()
+            .equal(5)
+            .nextAttribute("active", "or")
+            .descend()
+            .equal(true)
+
+        expect(JSON.parse(JSON.stringify(parsePantherFilterCSV(builder.returnCSV()))))
+            .toEqual(JSON.parse(JSON.stringify(builder.result())))
+    })
+})

--- a/tests/functional/convertor.sql.csv.spec.ts
+++ b/tests/functional/convertor.sql.csv.spec.ts
@@ -1,4 +1,4 @@
-import { PantherFilter, parsePantherFilterCSV } from "../../src/globals/filtering/convertor.sql.csv"
+import { PantherFilter, parsePantherFilterCSV, webEncodeFilterCSV, webDecodeFilterCSV } from "../../src/globals/filtering/convertor.sql.csv"
 
 describe("PantherFilter builder - single filter", () => {
     test("attribute and range setters build the expected filter", () => {
@@ -107,6 +107,28 @@ describe("PantherFilter returnCSV - serialization", () => {
         expect(csv.split("\n")).toHaveLength(2)
         expect(csv.split("\n")[1].startsWith("or, ")).toBe(true)
     })
+
+    test("returnEncodedCSV serializes to a single-line Base64url string", () => {
+        const builder = PantherFilter()
+            .attribute("price")
+            .from(10)
+            .to(100)
+            .descend()
+            .nextAttribute("qty", "and")
+            .ascend()
+            .equal(5)
+
+        const encoded = builder.returnEncodedCSV()
+
+        expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/)
+        expect(encoded).not.toContain("\n")
+        expect(encoded).not.toContain("+")
+        expect(encoded).not.toContain("/")
+        expect(encoded).not.toContain("=")
+
+        expect(JSON.parse(JSON.stringify(webDecodeFilterCSV(encoded))))
+            .toEqual(JSON.parse(JSON.stringify(builder.result())))
+    })
 })
 
 describe("parsePantherFilterCSV - parsing", () => {
@@ -187,5 +209,51 @@ describe("PantherFilter CSV round-trip", () => {
 
         expect(JSON.parse(JSON.stringify(parsePantherFilterCSV(builder.returnCSV()))))
             .toEqual(JSON.parse(JSON.stringify(builder.result())))
+    })
+})
+
+describe("webEncodeFilterCSV / webDecodeFilterCSV - Base64url transport", () => {
+    test("encoded output is single-line, URL-safe, and opaque", () => {
+        const filters = PantherFilter().attribute("price").from(10).to(100).descend().result()
+
+        const encoded = webEncodeFilterCSV(filters)
+
+        expect(encoded).toMatch(/^[A-Za-z0-9_-]+$/)
+        expect(encoded).not.toContain("\n")
+        expect(encoded).not.toContain("+")
+        expect(encoded).not.toContain("/")
+        expect(encoded).not.toContain("=")
+        expect(encoded).not.toBe(", price, 10, 100, , , descend, ")
+    })
+
+    test("round-trip reproduces the filters", () => {
+        const builder = PantherFilter()
+            .attribute("price")
+            .from(10)
+            .to(100)
+            .descend()
+            .nextAttribute("qty", "and")
+            .ascend()
+            .equal(5)
+            .nextAttribute("active", "or")
+            .descend()
+            .equal(true)
+
+        const decoded = webDecodeFilterCSV(webEncodeFilterCSV(builder.result()))
+
+        expect(JSON.parse(JSON.stringify(decoded)))
+            .toEqual(JSON.parse(JSON.stringify(builder.result())))
+    })
+
+    test("throws on empty input", () => {
+        expect(() => webDecodeFilterCSV(""))
+            .toThrow(/non-empty/i)
+        expect(() => webDecodeFilterCSV("   "))
+            .toThrow(/non-empty/i)
+    })
+
+    test("throws on invalid Base64url characters", () => {
+        expect(() => webDecodeFilterCSV("not valid !!!"))
+            .toThrow(/invalid Base64url/i)
     })
 })


### PR DESCRIPTION
Solves: #65 

- Adds JS builder to prepare universal filters for data service using chaining annotation.
- Output is encoded CSV (one attribute setup per row)
- Check Tests to see how to use it 